### PR TITLE
チーム情報の操作に関しての機能を整えること#

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -1,18 +1,18 @@
 class AssignsController < ApplicationController
   before_action :authenticate_user!
-  before_action :email_exist?, only: [:create]
-  before_action :user_exist?, only: [:create]
+
 
   def create
-    team = find_team(params[:team_id])
-    user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
-    if user
-      team.invite_member(user)
-      redirect_to team_url(team), notice: I18n.t('views.messages.assigned')
-    else
-      redirect_to team_url(team), notice: I18n.t('views.messages.failed_to_assign')
+      team = Team.friendly.find(params[:team_id])
+      user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
+      if user
+        team.invite_member(user)
+        redirect_to team_url(team), notice: I18n.t('views.messages.assigned')
+      else
+        redirect_to team_url(team), notice: I18n.t('views.messages.failed_to_assign')
+      end
     end
-  end
+
 
   def destroy
     assign = Assign.find(params[:id])
@@ -31,7 +31,8 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assign.destroy
+    elsif assigned_user == current_user || current_user == assign.team.owner
+      assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')
     else
@@ -39,30 +40,12 @@ class AssignsController < ApplicationController
     end
   end
 
-  def email_exist?
-    team = find_team(params[:team_id])
-    if team.members.exists?(email: params[:email])
-      redirect_to team_url(team), notice: I18n.t('views.messages.email_already_exists')
-    end
-  end
-
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
-  end
-
-  def user_exist?
-    team = find_team(params[:team_id])
-    unless User.exists?(email: params[:email])
-      redirect_to team_url(team), notice: I18n.t('views.messages.does_not_exist_email')
-    end
   end
 
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
-  end
-
-  def find_team(team_id)
-    team = Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,12 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    # TeamのeditはTeamのリーダー（オーナー）のみができるようにすること 
+    if @team.owner != current_user
+      redirect_to team_url(@team), notice: I18n.t('views.messages.failed_to_edit_team')
+    end
+  end
 
   def create
     @team = Team.new(team_params)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -210,8 +210,6 @@ ja:
       update_article: '記事更新に成功しました！'
       assigned: 'アサインしました！'
       failed_to_assign: 'アサインに失敗しました！'
-      email_already_exists: 'すでに同じメールアドレスが登録されています!'
-      does_not_exist_email: 'メールアドレスが存在しません。アカウントを作成してください。'
       cannot_delete_the_leader: 'リーダーは削除できません。'
       cannot_delete_only_a_member: 'このユーザーはこのチームにしか所属していないため、削除できません。'
       delete_member: 'メンバーを削除しました。'
@@ -253,6 +251,7 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      failed_to_edit_team: 'チームオーナーのみチーム情報を編集できます'
     button:
       submit: '投稿'
       edit: '編集'


### PR DESCRIPTION
Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
TeamのeditはTeamのリーダー（オーナー）のみができるようにすること
